### PR TITLE
fix a potential crash bug: 

### DIFF
--- a/modules/binding-jsonrpc-runtime/src/main/java/org/apache/tuscany/sca/binding/jsonrpc/provider/JSONRPCServiceServlet.java
+++ b/modules/binding-jsonrpc-runtime/src/main/java/org/apache/tuscany/sca/binding/jsonrpc/provider/JSONRPCServiceServlet.java
@@ -267,7 +267,7 @@ public class JSONRPCServiceServlet extends JSONRPCServlet {
             throw new RuntimeException("Unable to parse request", e);
         }
 
-        String method = jsonReq.getString("method");
+        String method = jsonReq.optString("method");
         if ((method != null) && (method.indexOf('.') < 0)) {
             jsonReq.putOpt("method", "Service" + "." + method);
         }


### PR DESCRIPTION
Location : modules/binding-jsonrpc-runtime/src/main/java/org/apache/tuscany/sca/binding/jsonrpc/provider/JSONRPCServiceServlet.java:270
JSONObject.getString() may throw exception and cause program crash. JSONObject.optString() should be used to avoid error, which will return a default value (null) if the query object does not exist